### PR TITLE
Use calculated norm for diffuse lighting

### DIFF
--- a/Day7/Main.elm
+++ b/Day7/Main.elm
@@ -215,7 +215,7 @@ void main () {
     // Diffuse lighting
     vec3 norm = normalize(vnormal);
     vec3 lightDir = normalize(lightPos - vpos);
-    float diff = max(dot(vnormal, lightDir), 0.0);
+    float diff = max(dot(norm, lightDir), 0.0);
     vec3 diffuse = diff * lightColor;
 
     // Specular lighting


### PR DESCRIPTION
Use correct normal value when calculating the diffuse lighting for softer values.

### Before

![screen shot 2017-04-22 at 13 54 28](https://cloud.githubusercontent.com/assets/199064/25303848/049ec58c-2764-11e7-93d0-5fd0f28c48f6.png)

### After

![screen shot 2017-04-22 at 13 55 11](https://cloud.githubusercontent.com/assets/199064/25303849/0b8c2bb4-2764-11e7-8069-85ee0f9476ea.png)
